### PR TITLE
Add more distribution metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,8 +6,16 @@ long_description = file:README.md
 long_description_content_type = text/markdown
 keywords = typing,pep585,pep604
 license = MIT
-license_file = LICENSE
+license_files =
+    LICENSE
+    AUTHORS
 url = https://github.com/cdce8p/python-typing-update
+classifier =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Topic :: Software Development
 
 [flake8]
 ignore = E203,E231,E701,W503,W504

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,12 @@
 name = python-typing-update
 author = Marc Mueller
 description = Update Python typing syntax
+long_description = file:README.md
+long_description_content_type = text/markdown
 keywords = typing,pep585,pep604
 license = MIT
+license_file = LICENSE
+url = https://github.com/cdce8p/python-typing-update
 
 [flake8]
 ignore = E203,E231,E701,W503,W504


### PR DESCRIPTION
The PyPI project page looks a bit bland at the moment, I suppose adding some metadata would help. In particular what I was looking for was project homepage URL.

https://pypi.org/project/python-typing-update/