### PR TITLE
Run release action on release-published

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   release:
     types:
-      - created
+      - published
 
 env:
   DEFAULT_PYTHON: 3.9


### PR DESCRIPTION
Release action wasn't triggered when release included additional files.
Use PR to test if type `published` solves that.