### PR TITLE
Packaging improvements

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,8 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Install requirements
         run: |
-          python -m pip install -U pip setuptools twine wheel
+          python -m pip install -U pip twine wheel
+          python -m pip install -U "setuptools>=56.0.0"
       - name: Build distributions
         run: |
           python setup.py sdist bdist_wheel

--- a/.gitignore
+++ b/.gitignore
@@ -179,4 +179,5 @@ Thumbs.db
 
 # -----
 # Custom / Overwrites
+!.vscode/settings.default.json
 .vscode/settings.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Build package",
             "type": "shell",
-            "command": "rm -rf build dist *.egg-info; source venv/bin/activate; python setup.py sdist bdist_wheel",
+            "command": "rm -rf build dist *.egg-info; ${command:python.interpreterPath} setup.py sdist bdist_wheel",
             "group": {
                 "kind": "build",
                 "isDefault": true,

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include requirements_black.txt


### PR DESCRIPTION
* Pin `setuptools` for release workflow
* Fix VS Code `Build package` task
* Fix sdist by including `MANIFEST.in`
* Update gitignore

~~Remove `setup.cfg` -> `license_files` once `setuptools` is updated~~
With setuptools [56.0.0](https://setuptools.readthedocs.io/en/latest/history.html#v56-0-0) license files are automatically included in the sdist. Technically that negates the need to specify them in the `setup.cfg`. I chose to leave it there for now, to be a bit more explicit.