### PR TITLE
Change dependabot rebase-strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     assignees:
       - "cdce8p"
     open-pull-requests-limit: 10
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -19,3 +20,4 @@ updates:
     assignees:
       - "cdce8p"
     open-pull-requests-limit: 10
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Prevent `dependabot` from rebasing open PRs after changes are detected.
https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#rebase-strategy