### PR TITLE
Improve test formatting

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,7 +13,7 @@ from python_typing_update.utils import async_restore_files
 FIXTURE_PATH = "tests/fixtures/"
 
 
-async def async_check_changes(filename: str, control: str):
+async def async_check_changes(filename: str, control: str) -> None:
     async with aiofiles.open(filename, 'r') as fp:
         content_modified: str = await fp.read()
 
@@ -37,7 +37,7 @@ async def async_test_main(
     argv: list[str] | None,
     returncode: int,
     capsys: CaptureFixture | None = None,
-):
+) -> None:
     filename = FIXTURE_PATH + filename
     control = FIXTURE_PATH + control
     if argv is None:
@@ -96,7 +96,7 @@ async def async_test_main(
             ['-v'], 12,
             id="debug",
         ),
-    )
+    ),
 )
 async def test_main(
     filename: str,
@@ -104,7 +104,7 @@ async def test_main(
     argv: list[str] | None,
     returncode: int,
     capsys: CaptureFixture,
-):
+) -> None:
     await async_test_main(filename, control, argv, returncode, capsys)
 
 
@@ -154,14 +154,14 @@ async def test_py_version(
             id="type_alias_pep604_310_updated",
             marks=pytest.mark.xfail(reason="Not implented in mypy + pyupgrade (yet)"),
         ),
-    )
+    ),
 )
 async def test_main_type_alias(
     filename: str,
     control: str,
     argv: list[str] | None,
     returncode: int,
-):
+) -> None:
     await async_test_main(filename, control, argv, returncode)
 
 
@@ -218,7 +218,7 @@ async def test_main_type_alias(
             ['--force'], 2,
             id="comment_5_forced",
         ),
-    )
+    ),
 )
 async def test_main_comment(
     filename: str,
@@ -226,7 +226,7 @@ async def test_main_comment(
     argv: list[str] | None,
     returncode: int,
     capsys: CaptureFixture,
-):
+) -> None:
     await async_test_main(filename, control, argv, returncode, capsys)
 
 
@@ -263,14 +263,14 @@ async def test_main_comment(
             None, 0,
             id="comment_no_issue_6",
         ),
-    )
+    ),
 )
 async def test_main_comment_no_issue(
     filename: str,
     control: str,
     argv: list[str] | None,
     returncode: int,
-):
+) -> None:
     await async_test_main(filename, control, argv, returncode)
 
 
@@ -297,14 +297,14 @@ async def test_main_comment_no_issue(
             None, 0,
             id="comment_import_no_issue_4",
         ),
-    )
+    ),
 )
 async def test_main_comment_import_no_issue(
     filename: str,
     control: str,
     argv: list[str] | None,
     returncode: int,
-):
+) -> None:
     await async_test_main(filename, control, argv, returncode)
 
 
@@ -371,7 +371,7 @@ async def test_main_comment_import_no_issue(
             ['--force'], 2,
             id="unused_import_8_forced",
         ),
-    )
+    ),
 )
 async def test_main_unused_import(
     filename: str,
@@ -379,7 +379,7 @@ async def test_main_unused_import(
     argv: list[str] | None,
     returncode: int,
     capsys: CaptureFixture,
-):
+) -> None:
     await async_test_main(filename, control, argv, returncode, capsys)
 
 
@@ -446,7 +446,7 @@ async def test_main_unused_import(
             ['--force'], 2,
             id="unused_import_comment_8_forced",
         ),
-    )
+    ),
 )
 async def test_main_unused_import_comment(
     filename: str,
@@ -454,7 +454,7 @@ async def test_main_unused_import_comment(
     argv: list[str] | None,
     returncode: int,
     capsys: CaptureFixture,
-):
+) -> None:
     await async_test_main(filename, control, argv, returncode, capsys)
 
 
@@ -471,12 +471,12 @@ async def test_main_unused_import_comment(
             ['--keep-updates'], 0,
             id="keep_updates",
         ),
-    )
+    ),
 )
 async def test_main_keep_updates(
     filename: str,
     control: str,
     argv: list[str] | None,
     returncode: int,
-):
+) -> None:
     await async_test_main(filename, control, argv, returncode)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+from textwrap import dedent
 
 import pytest
 
@@ -13,68 +14,68 @@ from python_typing_update.utils import (
     ('code', 'return_value'),
     (
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-# This is a comment
-import sys
-from typing import (
-    Any, List,
-    Union
-)
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            # This is a comment
+            import sys
+            from typing import (
+                Any, List,
+                Union
+            )
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.CLEAR,
             id="comment_before_imports_1",
         ),
         pytest.param(
-            """ \
-# This is a comment
-\"\"\"Long comment\"\"\"
-import sys
-from typing import (
-    Any, List,
-    Union
-)
+            dedent("""\
+            # This is a comment
+            \"\"\"Long comment\"\"\"
+            import sys
+            from typing import (
+                Any, List,
+                Union
+            )
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.CLEAR,
             id="comment_before_imports_2",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-import sys
-# This is a comment
-from typing import (
-    Any, List,
-    Union
-)
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            import sys
+            # This is a comment
+            from typing import (
+                Any, List,
+                Union
+            )
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.COMMENT,
             id="comment_between_imports_1",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-import sys
-\"\"\"Long comment (2)\"\"\"
-from typing import (
-    Any, List,
-    Union
-)
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            import sys
+            \"\"\"Long comment (2)\"\"\"
+            from typing import (
+                Any, List,
+                Union
+            )
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.COMMENT,
             id="comment_between_imports_2",
         ),
-    )
+    ),
 )
-def test_comment_detection(code: str, return_value: FileStatus):
+def test_comment_detection(code: str, return_value: FileStatus) -> None:
     fp = io.StringIO(code)
     assert check_comment_between_imports(fp) == return_value
 
@@ -83,74 +84,74 @@ def test_comment_detection(code: str, return_value: FileStatus):
     ('code', 'return_value'),
     (
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-import sys  # comment
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            import sys  # comment
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.CLEAR,
             id="comment_inline_import_clear",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-from sys import version  # comment
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            from sys import version  # comment
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.CLEAR,
             id="comment_inline_from_clear",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-from sys import version, version_info  # comment
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            from sys import version, version_info  # comment
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.COMMENT,
             id="comment_inline_from_2",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-from sys import argv, version, version_info  # comment
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            from sys import argv, version, version_info  # comment
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.COMMENT,
             id="comment_inline_from_3",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-from sys import (  # comment
-    argv, version,
-    version_info,
-)
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            from sys import (  # comment
+                argv, version,
+                version_info,
+            )
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.COMMENT,
             id="comment_inline_from_4",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-from sys import (
-    argv, version,
-    version_info  # comment
-)
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            from sys import (
+                argv, version,
+                version_info  # comment
+            )
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.COMMENT,
             id="comment_inline_from_5",
         ),
-    )
+    ),
 )
-def test_comment_detection_comment_inline(code: str, return_value: FileStatus):
+def test_comment_detection_comment_inline(code: str, return_value: FileStatus) -> None:
     fp = io.StringIO(code)
     assert check_comment_between_imports(fp) == return_value
 
@@ -159,91 +160,91 @@ def test_comment_detection_comment_inline(code: str, return_value: FileStatus):
     ('code', 'return_value'),
     (
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-import sys
-import typing  # comment
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            import sys
+            import typing  # comment
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.COMMENT | FileStatus.COMMENT_TYPING,
             id="comment_typing_import",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-import sys
-from typing import Any  # comment
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            import sys
+            from typing import Any  # comment
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.COMMENT | FileStatus.COMMENT_TYPING,
             id="comment_typing_from_1",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-import sys
-from typing import Any, List  # comment
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            import sys
+            from typing import Any, List  # comment
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.COMMENT | FileStatus.COMMENT_TYPING,
             id="comment_typing_from_2",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-import sys
-from typing import Any, List, Union  # comment
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            import sys
+            from typing import Any, List, Union  # comment
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.COMMENT | FileStatus.COMMENT_TYPING,
             id="comment_inline_3",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-import sys
-from typing import (  # comment
-    Any, List,
-    Union
-)
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            import sys
+            from typing import (  # comment
+                Any, List,
+                Union
+            )
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.COMMENT | FileStatus.COMMENT_TYPING,
             id="comment_typing_from_4",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-import sys
-from typing import (
-    Any, List,
-    Union  # comment
-)
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            import sys
+            from typing import (
+                Any, List,
+                Union  # comment
+            )
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.COMMENT | FileStatus.COMMENT_TYPING,
             id="comment_typing_from_5",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-from sys import argv, version # comment
-from typing import Any  # comment
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            from sys import argv, version # comment
+            from typing import Any  # comment
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.COMMENT | FileStatus.COMMENT_TYPING,
             id="comment_typing_multiple",
         ),
-    )
+    ),
 )
-def test_comment_detection_comment_typing(code: str, return_value: FileStatus):
+def test_comment_detection_comment_typing(code: str, return_value: FileStatus) -> None:
     fp = io.StringIO(code)
     assert check_comment_between_imports(fp) == return_value
 
@@ -252,36 +253,36 @@ def test_comment_detection_comment_typing(code: str, return_value: FileStatus):
     ('code', 'return_value'),
     (
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-import sys
-from typing import (
-    Any, List,
-    Union
-)
-# This is a comment
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            import sys
+            from typing import (
+                Any, List,
+                Union
+            )
+            # This is a comment
 
-var: Any = sys.version
-""",
+            var: Any = sys.version
+            """),
             FileStatus.CLEAR,
             id="comment_after_imports",
         ),
         pytest.param(
-            """ \
-\"\"\"Long comment\"\"\"
-import sys
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            import sys
 
-# This is a comment
-var: Any = sys.version
+            # This is a comment
+            var: Any = sys.version
 
-from typing import Any
-""",
+            from typing import Any
+            """),
             FileStatus.CLEAR,
             id="comment_after_first_import_block",
         ),
     )
 )
-def test_comment_detection_ignore_comment(code: str, return_value: FileStatus):
+def test_comment_detection_ignore_comment(code: str, return_value: FileStatus) -> None:
     fp = io.StringIO(code)
     assert check_comment_between_imports(fp) == return_value
 
@@ -290,72 +291,72 @@ def test_comment_detection_ignore_comment(code: str, return_value: FileStatus):
     ('code', 'import_set'),
     (
         pytest.param(
-            """
-var = 42
-import logging
-""",
+            dedent("""\
+            var = 42
+            import logging
+            """),
             set(),
             id="import_not_in_main_block",
         ),
         pytest.param(
-            """
-\"\"\"Long comment\"\"\"
-# another comment
-import logging
-import logging.handlers
-from logging import DEBUG
-from logging import INFO, WARNING
-""",
+            dedent("""\
+            \"\"\"Long comment\"\"\"
+            # another comment
+            import logging
+            import logging.handlers
+            from logging import DEBUG
+            from logging import INFO, WARNING
+            """),
             {"logging", "logging.handlers", "logging.DEBUG", "logging.INFO", "logging.WARNING"},
             id="absolute_imports",
         ),
         pytest.param(
-            """
-from .const import MY_CONST
-""",
+            dedent("""\
+            from .const import MY_CONST
+            """),
             {".const.MY_CONST"},
             id="relative_import",
         ),
         pytest.param(
-            """
-import logging as LOG
-from logging import ERROR as ER
-""",
+            dedent("""\
+            import logging as LOG
+            from logging import ERROR as ER
+            """),
             {"logging", "logging.ERROR"},
             id="import_with_re-export",
         ),
         pytest.param(
-            """
-import logging, sys
-from logging import (
-    DEBUG,
-    INFO,
-)
-""",
+            dedent("""\
+            import logging, sys
+            from logging import (
+                DEBUG,
+                INFO,
+            )
+            """),
             {"logging", "logging.DEBUG", "logging.INFO", "sys"},
             id="multiple_imports",
         ),
         pytest.param(
-            """
-import logging, \
-    sys
-from logging import DEBUG \
-    , INFO
-""",
+            dedent("""\
+            import logging, \
+                sys
+            from logging import DEBUG \
+                , INFO
+            """),
             {"logging", "logging.DEBUG", "logging.INFO", "sys"},
             id="multiple_import_2",
         ),
         pytest.param(
-            """
-import logging  # comment
-from logging import (  # comment
-    INFO)
-""",
+            dedent("""\
+            import logging  # comment
+            from logging import (  # comment
+                INFO)
+            """),
             {"logging", "logging.INFO"},
             id="imports_with_comments",
         ),
-    )
+    ),
 )
-def test_list_imports(code: str, import_set: set[str]):
+def test_list_imports(code: str, import_set: set[str]) -> None:
     fp = io.StringIO(code)
     assert extract_imports(fp) == import_set


### PR DESCRIPTION
* Add missing return type annotations
* Use `textwrap.dedent`
* Add trailing commas