### PR TITLE
Remove Python constraint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ so always check `git diff` before comitting any changes!
 Since this tool uses [pyupgrade][pyu], it's best used for
 projects that use it already.
 
+**Python 3.10**  
+This tool depends on `autoflake` which doesn't yet support Python 3.10.
+However, you can use `3.10` to update older Python syntax.
+
 
 ## Limitations
 Due to the way the tool works, it will reorder the imports multiple times.

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifier =
 
 [options]
 packages = find:
-python_requires = >=3.8,<3.10
+python_requires = >=3.8
 include_package_data = True
 install_requires =
     aiofiles==0.8.0


### PR DESCRIPTION
Remove upper Python constraint. Due to `autoflake`, Python 3.10 syntax isn't supported yet. It's however possible to use `3.10` to update older Python syntax.

Closes #97