### PR TITLE
Use custom autoflake version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ so always check `git diff` before comitting any changes!
 Since this tool uses [pyupgrade][pyu], it's best used for
 projects that use it already.
 
-**Python 3.10**  
-This tool depends on `autoflake` which doesn't yet support Python 3.10.
-However, you can use `3.10` to update older Python syntax.
-
 
 ## Limitations
 Due to the way the tool works, it will reorder the imports multiple times.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiofiles==0.8.0
-autoflake==1.4
+autoflake @ git+https://github.com/cdce8p/autoflake.git@v1.4.c1
 isort==5.10.1
 pyupgrade==2.32.0
 reorder-python-imports==3.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifier =
     Intended Audience :: Developers
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development
 
 [options]
@@ -25,7 +26,8 @@ python_requires = >=3.8
 include_package_data = True
 install_requires =
     aiofiles==0.8.0
-    autoflake==1.4
+    # Custom autoflake version to parse 3.10 syntax
+    autoflake @ git+https://github.com/cdce8p/autoflake.git@v1.4.c1
     isort==5.10.1
     pyupgrade==2.32.0
     reorder-python-imports==3.0.1


### PR DESCRIPTION
Custom autoflake version with replaces `lib2to3`. Thus we're now able to parse Python `3.10` syntax 🥳

https://github.com/cdce8p/autoflake/releases/tag/v1.4.c1
https://github.com/cdce8p/autoflake/compare/v1.4...v1.4.c1