### PR TITLE
Add note for rename limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ Due to the way the tool works, it will reorder the imports multiple times.
 By default the tool tries to detect if a comment was moved
 and revert all changes to the file. This can be overwritten by using `--force`.
 
+Currently, it's not possible to update aliases with a different name.
+In particular, these need to be updated manually:
+| Old typing name | New |
+| --------------- | --- |
+| `Deque` | `collections.deque` |
+| `DefaultDict` | `collections.defaultdict` |
+| `AbstractSet` | `collections.abc.Set` |
+| `ContextManager` | `contextlib.AbstractContextManager` |
+| `AsyncContextMananger` | `contextlib.AbstractAsyncContextManager` |
+
 
 ## How it works
 1. Run [python-reorder-import][pri] to add


### PR DESCRIPTION
https://github.com/asottile/reorder_python_imports doesn't (yet) support renaming names while updating imports.

https://github.com/asottile/reorder_python_imports/blob/c7cff569fb784bfda31d2a36fa67e9d24b4d90f5/reorder_python_imports.py#L509-L510