### PR TITLE
Revert pip install editable change [ci]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
   pull_request: ~
 
 env:
-  CACHE_VERSION: 2
+  CACHE_VERSION: 3
   DEFAULT_PYTHON: 3.8
   LIB_FOLDER: python_typing_update
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
@@ -50,7 +50,7 @@ jobs:
           . venv/bin/activate
           python -m pip install -U pip setuptools wheel
           pip install -U -r requirements.txt -r requirements_test.txt
-          pip install .
+          pip install -e .
       - name: Generate pre-commit restore key
         id: generate-pre-commit-key
         run: >-
@@ -107,7 +107,6 @@ jobs:
       - name: Run formatting check
         run: |
           . venv/bin/activate
-          pip install -e .
           pre-commit run --all-files
 
   pylint:
@@ -137,7 +136,6 @@ jobs:
       - name: Run pylint
         run: |
           . venv/bin/activate
-          pip install -e .
           pylint ${{ env.LIB_FOLDER }} tests
 
   mypy:
@@ -207,7 +205,7 @@ jobs:
           . venv/bin/activate
           python -m pip install -U pip setuptools wheel
           pip install -U -r requirements.txt -r requirements_test.txt
-          pip install .
+          pip install -e .
       - name: Run pytest
         run: |
           . venv/bin/activate


### PR DESCRIPTION
Editable install necessary to create file link back to cloned repo. Without it, the installed files would get reused. With caching this would mean that we don't test new changes (unless the cache version is bumped).