### PR TITLE
Remove manifest files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include requirements.txt
-include requirements_black.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifier =
 [options]
 packages = find:
 python_requires = >=3.8
-include_package_data = True
 install_requires =
     aiofiles==0.8.0
     # Custom autoflake version to parse 3.10 syntax


### PR DESCRIPTION
Requirement files don't need to be part of the `sdist` anymore. Requirements are specified in `setup.cfg` directly.
`include_package_data = True` is only used to include files from `MANIFEST.in` in the sdist.