### PR TITLE
Move metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,49 @@
 [build-system]
-requires = ["setuptools~=60.5", "wheel~=0.37.1"]
+requires = ["setuptools~=62.3", "wheel~=0.37.1"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name        = "python-typing-update"
+version     = "0.4.3.dev1"  # template: x.x.x[.dev1]
+license     = {text = "MIT"}
+description = "Update Python typing syntax"
+readme      = "README.md"
+authors     = [{name = "Marc Mueller"}]
+keywords    = ["typing", "pep585", "pep604"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Topic :: Software Development",
+]
+requires-python = ">=3.8"
+dependencies    = [
+    "aiofiles==0.8.0",
+    # Custom autoflake version to parse 3.10 syntax
+    "autoflake @ git+https://github.com/cdce8p/autoflake.git@v1.4.c1",
+    "isort==5.10.1",
+    "pyupgrade==2.32.1",
+    "reorder-python-imports==3.1.0",
+]
+
+[project.optional-dependencies]
+black = [
+    "black==22.3.0",
+]
+
+[project.scripts]
+python-typing-update = "python_typing_update.__main__:main"
+
+[tool.setuptools]
+license-files = ["LICENSE", "AUTHORS"]
+
+[tool.setuptools.package-data]
+"*" = ["py.typed", "*.pyi"]
+
+[tool.setuptools.packages.find]
+include = ["python_typing_update*"]
 
 [tool.isort]
 # https://pycqa.github.io/isort/docs/configuration/options.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,50 +1,8 @@
+# Setuptools v62.3 doesn't support editable installs with just 'pyproject.toml' (PEP 660).
+# Keep this file until it does!
+
 [metadata]
-name = python-typing-update
-# Version template: x.x.x[.dev1]
-version = 0.4.3.dev1
-author = Marc Mueller
-description = Update Python typing syntax
-long_description = file:README.md
-long_description_content_type = text/markdown
-keywords = typing,pep585,pep604
-license = MIT
-license_files =
-    LICENSE
-    AUTHORS
 url = https://github.com/cdce8p/python-typing-update
-classifier =
-    Development Status :: 4 - Beta
-    Intended Audience :: Developers
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Topic :: Software Development
-
-[options]
-packages = find:
-python_requires = >=3.8
-install_requires =
-    aiofiles==0.8.0
-    # Custom autoflake version to parse 3.10 syntax
-    autoflake @ git+https://github.com/cdce8p/autoflake.git@v1.4.c1
-    isort==5.10.1
-    pyupgrade==2.32.1
-    reorder-python-imports==3.1.0
-
-[options.extras_require]
-black =
-    black==22.3.0
-
-[options.package_data]
-* = py.typed, *.pyi
-
-[options.packages.find]
-include =
-    python_typing_update*
-
-[options.entry_points]
-console_scripts =
-    python-typing-update = python_typing_update.__main__:main
 
 [flake8]
 max_line_length = 119


### PR DESCRIPTION
Define project metadata in `pyproject.toml` -> [PEP 621](https://peps.python.org/pep-0621/).
https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html

**Notes**
* There isn't an equivalent to `url` just yet. `[project.urls]` has a sorting issue in PyPI.
* `Setuptools` doesn't yet support editable installs with only `pyproject.toml`, [PEP 660](https://peps.python.org/pep-0660/). Keep `setup.cfg` for now!