### PR TITLE
Add setup.py until dependabot issue is resolved

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+# Keep until dependabot issue is resolved
+# https://github.com/dependabot/dependabot-core/issues/4483
+
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
Dependabot doesn't work without `setup.py`. Add it back until issue is resolved.