### PR TITLE
Update autoflake to 1.7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ See [LICENSE][LICENSE_FILE] for the full license text.
 [pri]: https://github.com/asottile/reorder_python_imports
 [pyu]: https://github.com/asottile/pyupgrade
 [isort]: https://github.com/PyCQA/isort
-[autoflake]: https://github.com/myint/autoflake
+[autoflake]: https://github.com/PyCQA/autoflake
 [black]: https://github.com/psf/black
 [PEP585]: https://www.python.org/dev/peps/pep-0585/
 [PEP604]: https://www.python.org/dev/peps/pep-0604/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies    = [
     "aiofiles==22.1.0",
-    # Custom autoflake version to parse 3.10 syntax
-    "autoflake @ git+https://github.com/cdce8p/autoflake.git@v1.4.c1",
+    "autoflake==1.7.5",
     "isort==5.10.1",
     "pyupgrade==3.1.0",
     "reorder-python-imports==3.8.5",

--- a/python_typing_update/main.py
+++ b/python_typing_update/main.py
@@ -71,29 +71,24 @@ async def typing_update(
         return 2, filename
 
     # Check for unused imports (autoflake)
-    try:
-        await loop.run_in_executor(
-            None, autoflake_partial,
-            [None, '-c', filename],
-        )
-        if (
-            args.keep_updates is False
-            and args.full_reorder is False
-            and FileStatus.COMMENT_TYPING not in file_status
-        ):
-            # -> No unused imports, revert changes
-            return 2, filename
-    except SystemExit:
-        pass
+    status_autoflake = await loop.run_in_executor(
+        None, autoflake_partial,
+        [None, '-c', filename],
+    )
+    if (
+        status_autoflake == 0
+        and args.keep_updates is False
+        and args.full_reorder is False
+        and FileStatus.COMMENT_TYPING not in file_status
+    ):
+        # -> No unused imports, revert changes
+        return 2, filename
 
     # Remove unused imports (autoflake)
-    try:
-        await loop.run_in_executor(
-            None, autoflake_partial,
-            [None, '-i', filename],
-        )
-    except SystemExit:
-        pass
+    await loop.run_in_executor(
+        None, autoflake_partial,
+        [None, '-i', filename],
+    )
 
     # Run isort
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiofiles==22.1.0
-autoflake @ git+https://github.com/cdce8p/autoflake.git@v1.4.c1
+autoflake==1.7.5
 isort==5.10.1
 pyupgrade==3.1.0
 reorder-python-imports==3.8.5


### PR DESCRIPTION
[`autoflake`](https://github.com/PyCQA/autoflake) has been moved to the `PyCQA` org and is maintained once again. Switch back from fork to main branch.

Compare view: https://github.com/PyCQA/autoflake/compare/v1.4...v1.7.5