### PR TITLE
Add PyPI deployment environment [ci]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,9 @@ jobs:
   release-pypi:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
+    environment:
+      name: PyPI
+      url: https://pypi.org/project/python-typing-update/
     permissions:
       contents: write  # Required to upload release assets
     steps:


### PR DESCRIPTION
* https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
* https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules