### PR TITLE
Use new cache/restore action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
           check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.2.0
+        uses: actions/cache/restore@v3.2.0
         with:
           path: venv
           key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
@@ -109,7 +109,7 @@ jobs:
           exit 1
       - name: Restore pre-commit environment
         id: cache-precommit
-        uses: actions/cache@v3.2.0
+        uses: actions/cache/restore@v3.2.0
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
@@ -139,7 +139,7 @@ jobs:
           check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.2.0
+        uses: actions/cache/restore@v3.2.0
         with:
           path: venv
           key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
@@ -169,7 +169,7 @@ jobs:
           check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v3.2.0
+        uses: actions/cache/restore@v3.2.0
         with:
           path: venv
           key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{


### PR DESCRIPTION
`actions/cache/restore` skips the "Post restore cache" step. Useful for linting jobs as only an exact match is ever restored.
https://github.com/actions/cache/blob/v3.2.0/restore/README.md