### PR TITLE
Fix pytest-asyncio DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,9 @@ testpaths = ["tests"]
 norecursedirs = ["fixtures"]
 console_output_style = "count"
 log_level = "NOTSET"
-asyncio_mode = "auto"  # https://github.com/pytest-dev/pytest-asyncio#modes
+# https://pytest-asyncio.readthedocs.io/en/latest/reference/configuration.html
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.mypy]
 # https://mypy.readthedocs.io/en/stable/config_file.html


### PR DESCRIPTION
Fixes
```
/home/runner/work/ha-core/ha-core/venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py:208:
  PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope.
  Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope.
  Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future.
  Valid fixture loop scopes are: "function", "class", "module", "package", "session"
```